### PR TITLE
Small Updates

### DIFF
--- a/src/client.qc
+++ b/src/client.qc
@@ -492,7 +492,11 @@ void() ClientKill =
 	{
 		DropBackpack();
 	}
-	TeamCaptureDropFlagOfPlayer (self, 1);
+	if ((clanring_playmode & CLANRING_MATCH_MODE)&&(!(clanring_state & CLANRING_MATCH_STARTED)))
+		TeamCaptureDropFlagOfPlayer (self, 1);	//During Capture Time Trials (prematch); a suicide will return the flag back to base.
+	else
+		TeamCaptureDropFlagOfPlayer (self, 0);	//During a match or pickup mode, drop flag at origin of suicide.
+
 	UnHookPlayer();
 	self.hook2 = (self.hook2 - (self.hook2 & HOOK_OUT));//added for server mod hook
 	self.modelindex = modelindex_player;
@@ -1822,6 +1826,9 @@ void() PlayerPostThink =
 
 		if ((self.impulse >= 19) && (self.impulse != 22))
 		{
+			if (self.impulse != 39) //Remove afk status when the client issues an impulse command, *except* 39, which is our (automated) lag-out checker.
+				clear_afk_status(self);
+
 			if (self.impulse <= 250)
 				clanring_impulse ();
 		}
@@ -1989,8 +1996,13 @@ void() ClientDisconnect =
 	{
 		if (self.frags > 0)
 			announce5(self.netname, " left the game with ", s, " frag", pl);
-		else
-			announce2(self.netname, " disconnected.");
+		else 
+		{
+			if ((self.frags < 1) && (self.frags > -99))
+				announce5(self.netname, " rage-quit with ", s, " frag", pl);
+			else
+				announce2(self.netname, " disconnected.");	//observers
+		}
 	}
 	// ELOHIM_MOD - play gib sound if client was kicked for suiciding
 	if (!(clanring_playmode & CLANRING_MATCH_MODE) || !(clanring_state & CLANRING_MATCH_STARTED) || !(self.style & CLANRING_OBSERVER))//R00k: dont make a sound when match is going, unless a player disconnected.

--- a/src/ctf.qc
+++ b/src/ctf.qc
@@ -145,6 +145,8 @@ void(entity flg) TeamDropFlag =
 	flg.solid      	= SOLID_TRIGGER;
 	flg.movetype   	= MOVETYPE_TOSS;
 
+	sound(flg, CHAN_AUTO, "misc/basekey.wav", 1, ATTN_NONE);
+	
 	if (!(clanring_state & CLANRING_TEAM_CAPTURE_CUSTOM))
 	{
 		flg.angles = flg.angles + '0 0 180';

--- a/src/items.qc
+++ b/src/items.qc
@@ -702,6 +702,9 @@ void() weapon_touch =
 	if (!(other.flags & FL_CLIENT))
 		return;
 
+	if (other.health < 1)
+		return;
+
 // if the player was using his best weapon, change up to the new one if better		
 	stemp = self;
 	self = other;

--- a/src/match.qc
+++ b/src/match.qc
@@ -712,6 +712,8 @@ void() match_begin =
 	// Remove the spawnpoints' visible models
 	utils_do_match_spawns(spawns_remove_model);
 
+	find_pqc_teamscore_teams();// R00k: make sure everyone has the teamscores teams.
+	
 	if (clanring_playmode & CLANRING_CAPTURE_THE_FLAG)
 	{
 		TeamCaptureRegenFlags ();// respawn flags just to make sure
@@ -719,13 +721,12 @@ void() match_begin =
 	}
 
 	clanring_state = clanring_state | CLANRING_MATCH_STARTED;
-
 	announce("The match has begun!");//Moved up here for autodemo
-
 	utils_do_projectiles(SUB_Remove);
 	utils_do_players(match_gib_player);//3.19k : placed before rune remove
 	utils_do_item(SUB_Remove, "item_backpack");
-
+	utils_do_arena_players(arena_fight_and_shoot);
+	
 	if (clanring_playmode & CLANRING_RUNES)
 	{
 		utils_do_item(SUB_Remove, "item_rune");

--- a/src/quaketv.qc
+++ b/src/quaketv.qc
@@ -161,6 +161,9 @@ void (entity player) quaketv_obtained_rl =
 //
 void (entity player) quaketv_lost_rl = 
 {
+	if (match_prewar())	//R00k: fix assignment to world entity when someone type kill in prewar
+		return;
+
 	if (teamplay && (clanring_playmode & CLANRING_MATCH_MODE))
 	{
 		player.next_team.ammo_rockets = player.next_team.ammo_rockets - 1;

--- a/src/votables.qc
+++ b/src/votables.qc
@@ -251,7 +251,7 @@ void() votables_request_change_level =
 	}
 
 	level = (self.warp_episode * 15) + (self.warp_map);//new r00k
-	newmap = warpmap[level].name;
+	newmap = sprintf("%s (%s)", warpmap[level].name, warpmap[level].title);
 
 	//clear warp_flags;
 	self.warp_episode=0;
@@ -702,7 +702,7 @@ void(float newtype, float newmode, float newmap) votables_request_set_gametype_m
 	if (newmap)
 	{
 		self.use = SUB_Null;
-		request_mapname = warpmap[newmap].name;
+		request_mapname = sprintf("%s (%s)",warpmap[newmap].name,warpmap[newmap].title);
 	}
 
 	//clear warp_flags;

--- a/src/weapons.qc
+++ b/src/weapons.qc
@@ -1637,6 +1637,12 @@ void() W_WeaponFrame =
 	if (((mode_is_arena() == TRUE) && (boss.timetofight == FALSE)))
 		return;
 
+	//BuckSh0t: stop firing during timer countdown
+	if ((match_prewar()) && (clanring_state & CLANRING_TIMER_STARTED))
+	{
+		return;
+	}
+
 // check for attack
     // ELOHIM_MOD - don't fire unless ELOHIM_OK_TO_SHOOT is set
 	if (self.button0)

--- a/src/world.qc
+++ b/src/world.qc
@@ -345,7 +345,7 @@ void() worldspawn =
 
 	precache_sound ("boss1/sight1.wav"); //haste
 	precache_sound ("hknight/slash1.wav"); //rune toss
-
+	precache_sound ("misc/basekey.wav"); //flag dropped notification
 	precache_sound("buttons/switch04.wav"); //match timer countdown
 
 	//


### PR DESCRIPTION
weapon_touch ignores dead/dying players.
Append map title to the vote request, ie. "Someone requests to change map to ctf2m8 (Claustrophobopolis)." Remove afk status when the client issues an impulse command, *except* 39, which is our (automated) lag-out checker. added " rage-quit with " message for players that disconnect with negative frags. Fixed exploit with `kill` behavior with flagCarrier; flag drops to the ground, instead of returning to base. Added sound notification when a flag is dropped.
Disable firing in prewar when countdown begins
Fixed: assignment to world in quaketv_lost_rl, if player typed kill in prewar Resend `find_pqc_teamscore_teams` at countdown init and match start. Just in case the client missed it.