### PR TITLE
practice mode infokey fix

### DIFF
--- a/src/server.qc
+++ b/src/server.qc
@@ -326,6 +326,7 @@ void () server_set_infokey_modes =
 		{
 			if (clanring_playmode & CLANRING_PRACTICE_MODE)
 			{
+				zmode = ((clanring_playmode & CLANRING_CAPTURE_THE_FLAG) ? "ctf":"dm");
 				pmode = "practice";
 			}		
 		}


### PR DESCRIPTION
server.qc: update the 'mode' infokey to reflect CTF practice or DM practice.